### PR TITLE
Add `allow-empty` option for enabling empty commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,5 @@ out
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ jobs:
         tag: v1.0.3
 ```
 
+```yaml
+jobs:
+  <job-id>:
+    permissions:
+      contents: write # grant secrets.GITHUB_TOKEN permission to push file changes
+  
+    - name: Create empty commit
+      uses: ryancyq/github-signed-commit@v1
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        commit-message: Trigger rebuild
+        allow-empty: true
+```
+
 Note: The `GH_TOKEN` environment variable is **required** for GitHub API request authentication.
 
 ## Inputs
@@ -67,6 +82,7 @@ Note: The `GH_TOKEN` environment variable is **required** for GitHub API request
 | `branch-push-force` | **NO** | `--force` flag when running `git push <branch-name>`. |
 | `tag` | **NO** | Push tag for the new/current commit. |
 | `tag-only-if-file-changes` | **NO** | Push tag for new commit only when file changes present. **DEFAULT:** true |
+| `allow-empty` | **NO** | Allow creating commits even when no file changes are detected. **DEFAULT:** false |
 
 ## Outputs
 | Output | Description |

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,11 @@ inputs:
       Push tag for new commit only when file changes present.
     required: false
     default: true
+  allow-empty:
+    description: |
+      Allow creating commits even when no file changes are detected.
+    required: false
+    default: false
 
 outputs:
   commit-sha:

--- a/src/main.ts
+++ b/src/main.ts
@@ -109,9 +109,44 @@ export async function run(): Promise<void> {
       core.debug(`detect file changes: ${JSON.stringify(fileChanges)}`)
 
       if (fileCount <= 0) {
+        const allowEmpty = core.getBooleanInput('allow-empty')
         const skipTagCommit = core.getBooleanInput('tag-only-if-file-changes')
-        if (skipTagCommit) throw new NoFileChanges()
-        core.notice(new NoFileChanges().message)
+        
+        if (!allowEmpty && skipTagCommit) throw new NoFileChanges()
+        
+        if (allowEmpty) {
+          core.notice('No file changes detected, but proceeding with empty commit due to allow-empty option')
+          // Create empty commit
+          const commitMessage = core.getInput('commit-message', {
+            required: true,
+          })
+          core.debug(`commit message: ${commitMessage}`)
+          const createResponse = await core.group(
+            'committing empty commit',
+            async () => {
+              const startTime = Date.now()
+              const commitData = await createCommitOnBranch(
+                currentCommit,
+                commitMessage,
+                {
+                  repositoryNameWithOwner: repository.nameWithOwner,
+                  branchName: selectedBranch,
+                },
+                { additions: [], deletions: [] } // Empty file changes
+              )
+              const endTime = Date.now()
+              core.debug(`time taken: ${(endTime - startTime).toString()} ms`)
+              return commitData
+            }
+          )
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          createdCommit = createResponse.commit!
+          const commitSha = createdCommit.oid as string
+          core.info(`committed empty commit with ${commitSha}`)
+          core.setOutput('commit-sha', commitSha)
+        } else {
+          core.notice(new NoFileChanges().message)
+        }
       } else {
         const commitMessage = core.getInput('commit-message', {
           required: true,


### PR DESCRIPTION
This pull request introduces the `allow-empty` option, enabling users to create empty commits when no file changes are detected. This can be useful for triggering specific workflows or deployments that rely on commit events.